### PR TITLE
Don't test for multi run nor multi process on windows:

### DIFF
--- a/tasks/prep
+++ b/tasks/prep
@@ -249,6 +249,19 @@ find_make_pid()
 # Execute hooks
 prep_prepare()
 {
+    if [ $_host_os = windows ]
+    then
+      # windows runs on a newly created VM no need to check for multi run or existing builds.
+      newdir "$_xbrootdir"
+      if [ -s sources ]
+      then
+          makedir "$_sourcedir"
+      else
+          makedir "$_sourcedir/$_source"
+      fi
+      return 0
+    fi
+
     if [ ".$has_force" = .yes ]
     then
       newdir "$_xbrootdir"


### PR DESCRIPTION
The build are run on a clean VM each time.
Note that on cygwin ps doesn't support the -o option.
$ ps -p 1436 -o ppid=
ps: unknown option -- o
Try `ps --help' for more information.
...
So the fix fixes that too!